### PR TITLE
Serverless support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM public.ecr.aws/bitnami/node:15
-COPY --from=public.ecr.aws/m7b0o7h1/secret-env-vars-wrapper:latest-x86 /opt /opt
+COPY --from=public.ecr.aws/tinystacks/secret-env-vars-wrapper:latest-x86 /opt /opt
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.3.2-x86_64 /lambda-adapter /opt/extensions/lambda-adapter
 
 # Create app directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,5 @@ RUN npm run build
 # Bundle app source
 COPY . .
 
-EXPOSE 80
+EXPOSE 8000
 CMD [ "/opt/tinystacks-secret-env-vars-wrapper", "node", "built/server.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM public.ecr.aws/bitnami/node:15
+COPY --from=public.ecr.aws/m7b0o7h1/secret-env-vars-wrapper:latest-x86 /opt /opt
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.3.2-x86_64 /lambda-adapter /opt/extensions/lambda-adapter
 
 # Create app directory
 WORKDIR /usr/src/app
@@ -16,4 +18,4 @@ RUN npm run build
 COPY . .
 
 EXPOSE 80
-CMD [ "node", "built/server.js" ]
+CMD [ "/opt/tinystacks-secret-env-vars-wrapper", "node", "built/server.js" ]

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ curl http://127.0.0.1/ping
 
 If the server is running, this call will return an HTTP 200 (OK) result code. 
 
-By default the server starts on port 8000. You can change this to port 8000 by defining the environment variable `STAGE` and setting it to the value `local`. To bind to other ports, open the file `src/server.ts` and edit this line as needed: 
+By default the server starts on port 8000. To bind to other ports, open the file `src/server.ts` and edit this line as needed: 
 
 ```typescript
-const PORT = process.env.STAGE === "local" ? 8000 : 8000;
+const PORT = 8000;
 ```
 
 #### Adding an Item in Memory

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ curl http://127.0.0.1/ping
 
 If the server is running, this call will return an HTTP 200 (OK) result code. 
 
-By default the server starts on port 80. You can change this to port 8000 by defining the environment variable `STAGE` and setting it to the value `local`. To bind to other ports, open the file `src/server.ts` and edit this line as needed: 
+By default the server starts on port 8000. You can change this to port 8000 by defining the environment variable `STAGE` and setting it to the value `local`. To bind to other ports, open the file `src/server.ts` and edit this line as needed: 
 
 ```typescript
-const PORT = process.env.STAGE === "local" ? 8000 : 80;
+const PORT = process.env.STAGE === "local" ? 8000 : 8000;
 ```
 
 #### Adding an Item in Memory
@@ -127,7 +127,7 @@ To write to DynamoDB, the application must be running in a context in which it h
 
 The Dockerfile bundles the Express app (your app or the included sample app) onto a new Docker container image and runs the Express server.
 
-The Docker image itself derives from [Bitnami's Node.js image](https://gallery.ecr.aws/bitnami/node), which is made freely available on the [Amazon ECR Public Gallery](https://gallery.ecr.aws/) and is based on minideb, a minimalist Linux distribution. The Dockerfile uses the Node Package Manager (NPM) to install the Node.js packages required for the Express application as defined in the package-lock.json file. It then copies over the application's files and runs the Express server (as defined in the `src/server.ts` file) on port 80 of the container. 
+The Docker image itself derives from [Bitnami's Node.js image](https://gallery.ecr.aws/bitnami/node), which is made freely available on the [Amazon ECR Public Gallery](https://gallery.ecr.aws/) and is based on minideb, a minimalist Linux distribution. The Dockerfile uses the Node Package Manager (NPM) to install the Node.js packages required for the Express application as defined in the package-lock.json file. It then copies over the application's files and runs the Express server (as defined in the `src/server.ts` file) on port 8000 of the container. 
 
 If you have Docker installed, you can build and try out the sample application locally. Open a command prompt to the directory containing the Dockerfile and run the following command: 
 
@@ -135,10 +135,10 @@ If you have Docker installed, you can build and try out the sample application l
 docker build -t tinystacks/express-crud-app:latest .
 ```
 
-Once built, run the Docker command locally, mapping port 8080 on your host machine to port 80 on the container: 
+Once built, run the Docker command locally, mapping port 8080 on your host machine to port 8000 on the container: 
 
 ```
-docker run -p 8080:80 -d tinystacks/express-crud-app:latest
+docker run -p 8080:8000 -d tinystacks/express-crud-app:latest
 ```
 
 To test that the server is running, test its `/ping` endpoint from the command line. This time, you will change the port to 8080 to test that it's running from the running Docker container: 
@@ -214,10 +214,10 @@ COPY tsconfig.json ./
 COPY src ./src
 ```
 
-If your application uses a different port than port 80, you will also need to update the `EXPOSE` line in the Dockerfile to use a different port:
+If your application uses a different port than port 8000, you will also need to update the `EXPOSE` line in the Dockerfile to use a different port:
 
 ```Dockerfile
-EXPOSE 80
+EXPOSE 8000
 ```
 
 ## Known Limitations

--- a/release.yml
+++ b/release.yml
@@ -10,4 +10,18 @@ phases:
     on-failure: CONTINUE
     commands:
       - region="${STAGE_REGION:-$AWS_REGION}" 
-      - if [ -z "$SERVICE_NAME" ] || [ "$SERVICE_NAME" == "placeholder" ]; then echo 'Service is not ready yet. Repository tagged correctly, exiting now'; else  aws ecs update-service --service $SERVICE_NAME --cluster $CLUSTER_ARN --region $region --force-new-deployment; fi
+      - |
+        if [ ! -z "$LAMBDA_FUNCTION_NAME" -a  "$LAMBDA_FUNCTION_NAME" != "placeholder" ];
+          then
+            aws lambda update-function-code --function-name "$LAMBDA_FUNCTION_NAME" --image-uri "$ECR_IMAGE_URL:$STAGE_NAME" --region $region
+            imageSha=$(docker images --no-trunc --quiet $ECR_IMAGE_URL:$PREVIOUS_STAGE_NAME);
+            aws lambda tag-resource --resource "$LAMBDA_FUNCTION_ARN" --tags "IMAGE_SHA=$imageSha"
+          else
+            echo 'Not a serverless stage'
+            if [ -z "$SERVICE_NAME" ] || [ "$SERVICE_NAME" == "placeholder" ];
+              then
+                echo 'Service is not ready yet. Repository tagged correctly, exiting now';
+              else
+                aws ecs update-service --service $SERVICE_NAME --cluster $CLUSTER_ARN --region $region --force-new-deployment;
+            fi
+        fi

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,7 @@ import { deleteItem, getItem, putItem, updateItem, listItems } from "./local-ite
 
 
 // Constants
-const PORT = process.env.STAGE === "local" ? 8000 : 80;
+const PORT = 8000;
 const HOST = '0.0.0.0';
 
 // App handlers


### PR DESCRIPTION
This PR includes the following changes in order to support serverless hosting on lambda:
1. Include two lambda extensions in Dockerfile
    - One for adapting to Lambda events
    - One for Secrets Manager support
2. Update release.yml
3. Change default port
    - port 80 cannot be used on Lambda (no privileged port can be used i.e. below 1024)